### PR TITLE
Removed display_field parameter to get scripts working again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # interop2020-netbox-scripts
+
+Repairs the scripts to work in Netbox 3.0+, so developers can still follow along with this [great introduction to Netbox scripts](https://www.youtube.com/watch?v=mjyEJHUDpfk&t=140s) by @lampwins.

--- a/scripts/create_sites.py
+++ b/scripts/create_sites.py
@@ -25,7 +25,6 @@ class NewBranchScript(Script):
     switch_model = ObjectVar(
         description="Access switch model",
         model=DeviceType,
-        display_field='model',
         query_params={
             'manufacturer_id': '$manufacturer'
         }

--- a/scripts/snipeit_import.py
+++ b/scripts/snipeit_import.py
@@ -22,7 +22,6 @@ class SnipeITImportScript(Script):
     site = ObjectVar(
         description="Site",
         model=Site,
-        display_field='name'
     )
 
     def run(self, data, commit):


### PR DESCRIPTION
Support for the display_field parameter [was deprecated in Netbox 2.11](https://github.com/netbox-community/netbox/issues/5994), so the demo scripts would no longer work. This PR simply removes those lines, and the scripts function again. Tested on Netbox 3.3.4.

I recognize that there may not be an interest in maintaining this Interop demo, but it could be helpful for others just getting started by [watching your talk](https://www.youtube.com/watch?v=mjyEJHUDpfk&t=140s), so I felt obligated to give back by providing the fix. Either way, thanks for the video and demo repo. Cheers!